### PR TITLE
Fix styling for embedded ghost videos

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,2 @@
-require("./src/prism_styles/theme.css")
+require("./src/styles.css");
+require("./src/prism_styles/theme.css");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import { extendTheme, theme as base } from "@chakra-ui/react";
 
-
 const theme = extendTheme({
-    fonts: {
-        heading: `Montserrat, ${base.fonts?.heading}`,
-        body: `Inter, ${base.fonts?.body}`
-    }
+  fonts: {
+    heading: `Montserrat, ${base.fonts?.heading}`,
+    body: `Inter, ${base.fonts?.body}`,
+  },
 });
 
 export default theme;

--- a/src/rehype-visitors/fix-ghost-html.ts
+++ b/src/rehype-visitors/fix-ghost-html.ts
@@ -1,23 +1,34 @@
-import { visit } from 'unist-util-visit';
-import { LanguageUnion } from '../translations/langStrings';
-import { appendPostTrackingUtms } from '../utm_tracking';
+import { visit, Visited } from "unist-util-visit";
+import { LanguageUnion } from "../translations/langStrings";
+import { appendPostTrackingUtms } from "../utm_tracking";
 
-export const visit_and_fix_ghost_html = (options: { title: string, language: LanguageUnion }) => {
+export const visit_and_fix_ghost_html = (options: {
+  title: string;
+  language: LanguageUnion;
+}) => {
   return (tree) => {
-    visit(tree, 'element', visitor);
+    visit(tree, "element", visitor);
   };
 
   function visitor(node) {
-    if (node.tagName.startsWith('h')) {
+    if (node.tagName.startsWith("h")) {
       node.properties.className = [`cms-heading-${node.tagName}`];
-    } else if (node.tagName === 'a') {
-      
-      node.properties.href = appendPostTrackingUtms(options.title, options.language, node.properties.href)
+    } else if (node.tagName === "a") {
+      node.properties.href = appendPostTrackingUtms(
+        options.title,
+        options.language,
+        node.properties.href
+      );
       node.properties = {
         ...node.properties,
-        target: '_blank',
-        rel: 'noopener noreferrer',
+        target: "_blank",
+        rel: "noopener noreferrer",
       };
+    } else if (
+      node.tagName === "figure" &&
+      node.children[0].tagName === "iframe"
+    ) {
+      node.properties.className = ["youtube-video-container"];
     }
   }
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,23 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter&family=Montserrat&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter&family=Montserrat&display=swap");
+
+/* wow, github copilot helped me to write CSS! thank you, co-pilot! looks good! */
+.youtube-video-container {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  margin: 0 auto;
+  overflow: hidden;
+  max-width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+}
+
+.youtube-video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 8px;
+}


### PR DESCRIPTION
<img width="1079" alt="Screenshot 2024-02-27 at 12 01 27" src="https://github.com/trkohler/blg/assets/49440211/a8d8ca6b-b1bd-4222-8d11-ec1c6ccd4d69">

now videos looks better. Previously it was like that:

<img width="1038" alt="Screenshot 2024-02-27 at 12 01 55" src="https://github.com/trkohler/blg/assets/49440211/5ac9ce2c-ad2f-44ca-a2b1-15d4ec54568b">

I don't know anything in CSS, but Github Copilot helped me! 🎉 